### PR TITLE
Synchronize receipt of Get SCU images

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,21 @@ Performs C-STORE as a Service Class Provider (Listener).
 |:--------------|:-------------------|:------------------------------|
 | `DicomObject` | `application/java` | [DICOM Object](#dicom-object) |
 
+### Get SCU Results
+Receives each image from the `Get SCU to Flow` operation. See [Get SCU to Flow](#get-scu-to-flow) for more details.
+
+#### Outbound Attributes
+| Name       | Description                                                               |
+|:-----------|:--------------------------------------------------------------------------|
+| action     | `start`, `receive`, or `stop`                                             |
+| seriesName | Value from the `Series name` parameter of the `Get SCU to Flow` operation |
+| iuid       | Instance UID of the DICOM image                                           |
+
+#### Outbound Payload
+| Data Type     | Media Type         | Description                   |
+|:--------------|:-------------------|:------------------------------|
+| `DicomObject` | `application/java` | [DICOM Object](#dicom-object) |
+
 Operations
 ----------
 ### Apply Preamble
@@ -245,6 +260,40 @@ Saves each DICOM file to an Object Store as a byte array, returning an ArrayList
 | Presentation Context | Presentation Context | Transfer Syntax         | `IMPLICIT_FIRST` |                                                                                               |
 | Timings              | Timings              | Store Timeout           | `0`              |                                                                                               |
 | Timings              | Timings              | Cancel After            | `0`              | Milliseconds to wait on each operation before throwing DICOM:CANCELED (0 is infinite)         |
+
+#### Output Payload
+`GetScuPayload` object with the following properties:
+
+| Property Name                  | Type           |
+|:-------------------------------|:---------------|
+| messageId                      | `int`          |
+| messageIdBeingRespondedTo      | `int`          |
+| affectedSOPClassUID            | `String`       |
+| numberOfCompletedSuboperations | `int`          |
+| numberOfFailedSuboperations    | `int`          |
+| numberOfRemainingSuboperations | `int`          |
+| numberOfWarningSuboperations   | `int`          |
+| filenames                      | `List<String>` |
+
+### Get SCU to Flow
+Performs C-GET as a Service Class User with a remote Application Entity.
+When the operation starts, it sends an empty message to the `Get SCU Results` listener with the `attributes.action` of `start`.
+Each DICOM file that is received is sent to the `Get SCU Results` listener with the `attributes.action` of `receive`.
+After the last image is received, it sends an empty message to the `Get SCU Results` listener with the `attributes.action` of `stop`.
+
+#### Parameters
+| Tab                  | Group                | Parameter               | Default          | Description                                                                                                                            |
+|:---------------------|:---------------------|:------------------------|:-----------------|:---------------------------------------------------------------------------------------------------------------------------------------|
+| General              | Basic Settings       | Connector configuration |                  | See [DICOM User](#dicom-user)                                                                                                          |
+| General              | General              | Target flow name        |                  | Name of a Flow that has a [Get SCU Results](#get-scu-results) listener as its source.                                                  |
+| General              | General              | Series name             |                  | A string that is included as an attribute to the target flow. Intended to be used to identify all of the images returned by the C-GET. |
+| General              | Search               | Search Keys             | `#[payload]`     | See [Search Keys](#search-keys)                                                                                                        |
+| General              | Search               | Storage SOP Classes     | `None`           | See [Storage SOP Classes](#storage-sop-classes)                                                                                        |
+| Presentation Context | Presentation Context | Information Model       | `STUDY_ROOT`     |                                                                                                                                        |
+| Presentation Context | Presentation Context | Retrieve Level          |                  |                                                                                                                                        |
+| Presentation Context | Presentation Context | Transfer Syntax         | `IMPLICIT_FIRST` |                                                                                                                                        |
+| Timings              | Timings              | Store Timeout           | `0`              |                                                                                                                                        |
+| Timings              | Timings              | Cancel After            | `0`              | Milliseconds to wait on each operation before throwing DICOM:CANCELED (0 is infinite)                                                  |
 
 #### Output Payload
 `GetScuPayload` object with the following properties:

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.jh.pm</groupId>
     <artifactId>dicom-connector</artifactId>
-    <version>4.2.5</version>
+    <version>4.2.6</version>
     <packaging>mule-extension</packaging>
     <name>Dicom Extension</name>
 
@@ -26,7 +26,7 @@
         <!-- DICOM Library https://dcm4che.org/maven2/org/dcm4che/dcm4che-core/maven-metadata.xml -->
         <!-- DICOM Library https://dcm4che.org/maven2/org/dcm4che/dcm4che-net/maven-metadata.xml -->
         <!-- DICOM Library https://dcm4che.org/maven2/org/dcm4che/tool/dcm4che-tool-common/maven-metadata.xml -->
-        <dcm4che.version>5.29.1</dcm4che.version>
+        <dcm4che.version>5.29.2</dcm4che.version>
     </properties>
 
     <dependencies>
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.1</version>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.jh.pm</groupId>
     <artifactId>dicom-connector</artifactId>
-    <version>4.2.3</version>
+    <version>4.2.4</version>
     <packaging>mule-extension</packaging>
     <name>Dicom Extension</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>edu.jh.pm</groupId>
     <artifactId>dicom-connector</artifactId>
-    <version>4.2.4</version>
+    <version>4.2.5</version>
     <packaging>mule-extension</packaging>
     <name>Dicom Extension</name>
 

--- a/src/main/java/org/mule/module/dicom/internal/config/GetScuResultsValueProvider.java
+++ b/src/main/java/org/mule/module/dicom/internal/config/GetScuResultsValueProvider.java
@@ -1,0 +1,32 @@
+package org.mule.module.dicom.internal.config;
+
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.api.component.location.ConfigurationComponentLocator;
+import org.mule.runtime.api.value.Value;
+import org.mule.runtime.extension.api.values.ValueBuilder;
+import org.mule.runtime.extension.api.values.ValueProvider;
+
+import javax.inject.Inject;
+import java.util.*;
+
+public class GetScuResultsValueProvider implements ValueProvider {
+    @Inject
+    private ConfigurationComponentLocator configurationComponentLocator;
+
+    @Override
+    public Set<Value> resolve() {
+        List<String> componentList = new ArrayList<>();
+        if (configurationComponentLocator != null) {
+            List<ComponentLocation> allLocations = configurationComponentLocator.findAllLocations();
+            for (ComponentLocation location : allLocations) {
+                String namespace = location.getComponentIdentifier().getIdentifier().getNamespace();
+                String name = location.getComponentIdentifier().getIdentifier().getName();
+                if (namespace.equals("dicom") && name.equals("get-scu-results")) {
+                    String locationName = location.getLocation();
+                    componentList.add(locationName.substring(0, locationName.indexOf('/')));
+                }
+            }
+        }
+        return ValueBuilder.getValuesFor(componentList);
+    }
+}

--- a/src/main/java/org/mule/module/dicom/internal/config/ScpConfiguration.java
+++ b/src/main/java/org/mule/module/dicom/internal/config/ScpConfiguration.java
@@ -8,6 +8,7 @@
 package org.mule.module.dicom.internal.config;
 
 import org.mule.module.dicom.internal.connection.StoreScpConnectionProvider;
+import org.mule.module.dicom.internal.source.GetScuResults;
 import org.mule.module.dicom.internal.source.StoreScp;
 import org.mule.runtime.extension.api.annotation.Configuration;
 import org.mule.runtime.extension.api.annotation.Sources;
@@ -15,5 +16,5 @@ import org.mule.runtime.extension.api.annotation.connectivity.ConnectionProvider
 
 @Configuration(name="provider")
 @ConnectionProviders(StoreScpConnectionProvider.class)
-@Sources(StoreScp.class)
+@Sources({StoreScp.class, GetScuResults.class})
 public class ScpConfiguration { }

--- a/src/main/java/org/mule/module/dicom/internal/notification/DownloadNotificationAction.java
+++ b/src/main/java/org/mule/module/dicom/internal/notification/DownloadNotificationAction.java
@@ -11,9 +11,9 @@ import org.mule.runtime.api.metadata.DataType;
 import org.mule.runtime.extension.api.notification.NotificationActionDefinition;
 
 public enum DownloadNotificationAction implements NotificationActionDefinition<DownloadNotificationAction> {
-    SAVED(DataType.fromType(String.class)),
-
-    FINISHED(DataType.fromType(Boolean.class));
+    SAVED(DataType.STRING),
+    STARTED(DataType.STRING),
+    FINISHED(DataType.BOOLEAN);
 
     private final DataType dataType;
 

--- a/src/main/java/org/mule/module/dicom/internal/notification/DownloadNotificationActionProvider.java
+++ b/src/main/java/org/mule/module/dicom/internal/notification/DownloadNotificationActionProvider.java
@@ -19,6 +19,7 @@ public class DownloadNotificationActionProvider implements NotificationActionPro
     public Set<NotificationActionDefinition> getNotificationActions() {
         HashSet<NotificationActionDefinition> actions = new HashSet<>();
         actions.add(DownloadNotificationAction.SAVED);
+        actions.add(DownloadNotificationAction.STARTED);
         actions.add(DownloadNotificationAction.FINISHED);
         return actions;
     }

--- a/src/main/java/org/mule/module/dicom/internal/operation/ScuOperations.java
+++ b/src/main/java/org/mule/module/dicom/internal/operation/ScuOperations.java
@@ -11,12 +11,14 @@ import org.dcm4che3.data.UID;
 import org.dcm4che3.io.DicomInputStream;
 import org.mule.module.dicom.api.content.*;
 import org.mule.module.dicom.api.parameter.*;
+import org.mule.module.dicom.internal.config.GetScuResultsValueProvider;
 import org.mule.module.dicom.internal.config.ScuType;
 import org.mule.module.dicom.internal.connection.ScuConnection;
 import org.mule.module.dicom.internal.notification.DownloadNotificationAction;
 import org.mule.module.dicom.internal.notification.DownloadNotificationActionProvider;
 import org.mule.module.dicom.internal.store.DicomFileType;
 import org.mule.module.dicom.internal.store.MuleFileStore;
+import org.mule.module.dicom.internal.store.MuleGetScuStore;
 import org.mule.module.dicom.internal.store.MuleObjectStore;
 import org.mule.module.dicom.internal.util.AttribUtils;
 import org.mule.module.dicom.internal.config.ScuOperationConfig;
@@ -35,6 +37,7 @@ import org.mule.runtime.extension.api.annotation.error.Throws;
 import org.mule.runtime.extension.api.annotation.notification.Fires;
 import org.mule.runtime.extension.api.annotation.param.*;
 import org.mule.runtime.extension.api.annotation.param.display.*;
+import org.mule.runtime.extension.api.annotation.values.OfValues;
 import org.mule.runtime.extension.api.exception.ModuleException;
 import org.mule.runtime.extension.api.notification.NotificationEmitter;
 
@@ -51,6 +54,7 @@ import java.util.concurrent.locks.Lock;
 import static org.mule.runtime.api.meta.model.display.PathModel.Type.DIRECTORY;
 
 public class ScuOperations {
+    private static final String NOT_FOUND = "C-GET Received 0 Files";
     @Inject
     private LockFactory lockFactory;
     @Inject
@@ -60,29 +64,27 @@ public class ScuOperations {
     @DisplayName("Echo SCU")
     @Summary("Performs C-ECHO as a Service Class User with a remote Application Entity.")
     @Throws(ScuErrorsProvider.class)
-    public EchoScuPayload
+    public synchronized EchoScuPayload
     echoScu(@Connection ScuConnection connection,
             @ParameterGroup(name=Timings.PARAMETER_GROUP)
             Timings timings
     ) {
-        synchronized (this) {
-            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.ECHO);
-            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
-            scuOperationConfig.setSopClassUid(UID.Verification);
-            scuOperationConfig.setTransferSyntaxUid(UID.ImplicitVRLittleEndian);
+        ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.ECHO);
+        scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+        scuOperationConfig.setSopClassUid(UID.Verification);
+        scuOperationConfig.setTransferSyntaxUid(UID.ImplicitVRLittleEndian);
 
-            EchoScu echoScu = EchoScu.execute(connection, scuOperationConfig);
-            if (!echoScu.getSuccess()) {
-                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(echoScu.getErrorMessage()));
-            }
-            return new EchoScuPayload(echoScu);
+        EchoScu echoScu = EchoScu.execute(connection, scuOperationConfig);
+        if (!echoScu.getSuccess()) {
+            throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(echoScu.getErrorMessage()));
         }
+        return new EchoScuPayload(echoScu);
     }
 
     @DisplayName("Find SCU")
     @Summary("Performs C-FIND as a Service Class User with a remote Application Entity.")
     @Throws(ScuErrorsProvider.class)
-    public FindScuPayload
+    public synchronized FindScuPayload
     findScu(@Connection ScuConnection connection,
             @ParameterGroup(name=TagSearch.PARAMETER_GROUP)
             TagSearch tagSearch,
@@ -91,33 +93,31 @@ public class ScuOperations {
             @ParameterGroup(name=Timings.PARAMETER_GROUP)
             Timings timings
     ) {
-        synchronized (this) {
-            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.FIND);
-            scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
-            scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
-            scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
-            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+        ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.FIND);
+        scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
+        scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
+        scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
+        scuOperationConfig.setCancelAfter(timings.getCancelAfter());
 
-            Map<String, Object> keys = new HashMap<>(tagSearch.getSearchKeys());
-            for (String tagName : tagSearch.getResponseTags()) {
-                if (!keys.containsKey("tagName")) keys.put(tagName, "");
-            }
-            FindScu findScu = FindScu.execute(connection, scuOperationConfig, keys);
-            if (!findScu.getSuccess()) {
-                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(findScu.getErrorMessage()));
-            }
-            if (findScu.getPayload().isEmpty()) {
-                throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException("C-FIND Received 0 Results"));
-            }
-            return new FindScuPayload(findScu);
+        Map<String, Object> keys = new HashMap<>(tagSearch.getSearchKeys());
+        for (String tagName : tagSearch.getResponseTags()) {
+            if (!keys.containsKey("tagName")) keys.put(tagName, "");
         }
+        FindScu findScu = FindScu.execute(connection, scuOperationConfig, keys);
+        if (!findScu.getSuccess()) {
+            throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(findScu.getErrorMessage()));
+        }
+        if (findScu.getPayload().isEmpty()) {
+            throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException("C-FIND Received 0 Results"));
+        }
+        return new FindScuPayload(findScu);
     }
 
     @DisplayName("Get SCU to File System")
     @Summary("Performs C-GET as a Service Class User with a remote Application Entity.")
     @Fires(DownloadNotificationActionProvider.class)
     @Throws(ScuErrorsProvider.class)
-    public GetScuPayload
+    public synchronized GetScuPayload
     getScu(@Connection ScuConnection connection,
            @DisplayName("Folder Name")
            @Summary("Folder where all files are saved")
@@ -137,34 +137,32 @@ public class ScuOperations {
         Lock lock = (lockFactory != null) ? lockFactory.createLock(folderName) : null;
         if (lock != null) lock.lock();
         try {
-            synchronized (this) {
-                if (notificationEmitter != null)
-                    notificationEmitter.fire(DownloadNotificationAction.STARTED, TypedValue.of(folderName));
-                ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.GET);
-                scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
-                scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
-                scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
-                scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
-                scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
-                scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.STARTED, TypedValue.of(folderName));
+            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.GET);
+            scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
+            scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
+            scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
+            scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
+            scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
+            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
 
-                MuleFileStore muleStore;
-                try {
-                    muleStore = new MuleFileStore(folderName, notificationEmitter, compressFiles);
-                } catch (IOException e) {
-                    throw new ModuleException(DicomError.FILE_IO, e);
-                }
-                GetScu getScu = GetScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys(), muleStore);
-                if (notificationEmitter != null)
-                    notificationEmitter.fire(DownloadNotificationAction.FINISHED, TypedValue.of(!getScu.getPayload().isEmpty()));
-                if (getScu.getHasError()) {
-                    throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(getScu.getErrorMessage()));
-                }
-                if (getScu.getPayload().isEmpty()) {
-                    throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException("C-GET Received 0 Files"));
-                }
-                return new GetScuPayload(getScu);
+            MuleFileStore muleStore;
+            try {
+                muleStore = new MuleFileStore(folderName, notificationEmitter, compressFiles);
+            } catch (IOException e) {
+                throw new ModuleException(DicomError.FILE_IO, e);
             }
+            GetScu getScu = GetScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys(), muleStore);
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.FINISHED, TypedValue.of(!getScu.getPayload().isEmpty()));
+            if (getScu.getHasError()) {
+                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(getScu.getErrorMessage()));
+            }
+            if (getScu.getPayload().isEmpty()) {
+                throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException(NOT_FOUND));
+            }
+            return new GetScuPayload(getScu);
         } finally {
             if (lock != null) lock.unlock();
         }
@@ -174,7 +172,7 @@ public class ScuOperations {
     @Summary("Performs C-GET as a Service Class User with a remote Application Entity. Send all DICOM objects to an Object Store.")
     @Fires(DownloadNotificationActionProvider.class)
     @Throws(ScuErrorsProvider.class)
-    public GetScuPayload
+    public synchronized GetScuPayload
     getScuObjectStore(@Connection ScuConnection connection,
                       @ParameterDsl(allowInlineDefinition = false) @Expression(ExpressionSupport.NOT_SUPPORTED) ObjectStore<byte[]> objectStore,
                       @Summary("Prefix to use for each key name. Each file's Instance UID will be appended, following a colon.") String keyNamePrefix,
@@ -189,29 +187,75 @@ public class ScuOperations {
         Lock lock = (lockFactory != null) ? lockFactory.createLock(keyNamePrefix) : null;
         if (lock != null) lock.lock();
         try {
-            synchronized (this) {
-                if (notificationEmitter != null)
-                    notificationEmitter.fire(DownloadNotificationAction.STARTED, TypedValue.of(keyNamePrefix));
-                ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.GET);
-                scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
-                scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
-                scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
-                scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
-                scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
-                scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.STARTED, TypedValue.of(keyNamePrefix));
+            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.GET);
+            scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
+            scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
+            scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
+            scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
+            scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
+            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
 
-                MuleObjectStore muleStore = new MuleObjectStore(objectStore, keyNamePrefix);
-                GetScu getScu = GetScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys(), muleStore);
-                if (notificationEmitter != null)
-                    notificationEmitter.fire(DownloadNotificationAction.FINISHED, TypedValue.of(!getScu.getPayload().isEmpty()));
-                if (getScu.getHasError()) {
-                    throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(getScu.getErrorMessage()));
-                }
-                if (getScu.getPayload().isEmpty()) {
-                    throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException("C-GET Received 0 Files"));
-                }
-                return new GetScuPayload(getScu);
+            MuleObjectStore muleStore = new MuleObjectStore(objectStore, keyNamePrefix);
+            GetScu getScu = GetScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys(), muleStore);
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.FINISHED, TypedValue.of(!getScu.getPayload().isEmpty()));
+            if (getScu.getHasError()) {
+                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(getScu.getErrorMessage()));
             }
+            if (getScu.getPayload().isEmpty()) {
+                throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException(NOT_FOUND));
+            }
+            return new GetScuPayload(getScu);
+        } finally {
+            if (lock != null) lock.unlock();
+        }
+    }
+
+    @DisplayName("Get SCU to Flow")
+    @Summary("Performs C-GET as a Service Class User with a remote Application Entity. Send all DICOM objects to a Get SCU Results flow listener.")
+    @Fires(DownloadNotificationActionProvider.class)
+    @Throws(ScuErrorsProvider.class)
+    public synchronized GetScuPayload
+    getScuFlowStore(@Connection ScuConnection connection,
+                    @OfValues(GetScuResultsValueProvider.class) @ParameterDsl(allowInlineDefinition = false) @Expression(ExpressionSupport.NOT_SUPPORTED)
+                            @Summary("Name of a flow that contains a Get SCU Results listener")
+                    String targetFlowName,
+                    @Summary("Value that gets populated on the 'seriesName' attribute of each flow message.") String seriesName,
+                    @ParameterGroup(name= StoreSearch.PARAMETER_GROUP)
+                    StoreSearch storeSearch,
+                    @ParameterGroup(name= PresentationContext.PARAMETER_GROUP)
+                    PresentationContext presentationContext,
+                    @ParameterGroup(name= StoreTimings.PARAMETER_GROUP)
+                    StoreTimings timings,
+                    NotificationEmitter notificationEmitter) {
+        Lock lock = (lockFactory != null) ? lockFactory.createLock(seriesName) : null;
+        if (lock != null) lock.lock();
+        try {
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.STARTED, TypedValue.of(seriesName));
+            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.GET);
+            scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
+            scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
+            scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
+            scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
+            scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
+            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+
+            MuleGetScuStore muleStore = new MuleGetScuStore(targetFlowName, seriesName);
+            GetScu getScu = GetScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys(), muleStore);
+            if (notificationEmitter != null)
+                notificationEmitter.fire(DownloadNotificationAction.FINISHED, TypedValue.of(!getScu.getPayload().isEmpty()));
+            if (getScu.getHasError()) {
+                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(getScu.getErrorMessage()));
+            }
+            if (getScu.getPayload().isEmpty()) {
+                throw new ModuleException(DicomError.NOT_FOUND, new RuntimeException(NOT_FOUND));
+            }
+            return new GetScuPayload(getScu);
+        } catch (IOException e) {
+            throw new ModuleException(DicomError.FILE_IO, e);
         } finally {
             if (lock != null) lock.unlock();
         }
@@ -220,7 +264,7 @@ public class ScuOperations {
     @DisplayName("Move SCU")
     @Summary("Performs C-MOVE as a Service Class User with a remote Application Entity.")
     @Throws(ScuErrorsProvider.class)
-    public MoveScuPayload
+    public synchronized MoveScuPayload
     moveScu(@Connection ScuConnection connection,
             @ParameterGroup(name=StoreSearch.PARAMETER_GROUP)
             StoreSearch storeSearch,
@@ -229,28 +273,26 @@ public class ScuOperations {
             @ParameterGroup(name=StoreTimings.PARAMETER_GROUP)
             StoreTimings timings
     ) {
-        synchronized (this) {
-            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.MOVE);
-            scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
-            scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
-            scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
-            scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
-            scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
-            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+        ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.MOVE);
+        scuOperationConfig.setInformationModel(presentationContext.getInformationModel());
+        scuOperationConfig.setRetrieveLevel(presentationContext.getRetrieveLevel());
+        scuOperationConfig.setTransferSyntax(presentationContext.getTransferSyntax());
+        scuOperationConfig.setSopClasses(storeSearch.getSopClasses());
+        scuOperationConfig.setStoreTimeout(timings.getStoreTimeout());
+        scuOperationConfig.setCancelAfter(timings.getCancelAfter());
 
-            MoveScu moveScu = MoveScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys());
-            if (!moveScu.getSuccess()) {
-                throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(moveScu.getErrorMessage()));
-            }
-            return new MoveScuPayload(moveScu);
+        MoveScu moveScu = MoveScu.execute(connection, scuOperationConfig, storeSearch.getSearchKeys());
+        if (!moveScu.getSuccess()) {
+            throw new ModuleException(DicomError.REQUEST_ERROR, new RuntimeException(moveScu.getErrorMessage()));
         }
+        return new MoveScuPayload(moveScu);
     }
 
     @MediaType("application/java")
     @DisplayName("Store SCU")
     @Summary("Performs C-STORE as a Service Class User with a remote Application Entity.")
     @Throws(ScuErrorsProvider.class)
-    public List<String>
+    public synchronized List<String>
     storeScu(@Connection ScuConnection connection,
              @ParameterGroup(name=StoreImage.PARAMETER_GROUP)
              StoreImage storeImage,
@@ -265,92 +307,91 @@ public class ScuOperations {
              @ParameterGroup(name=Timings.PARAMETER_GROUP)
              Timings timings
     ) {
-        synchronized (this) {
-            ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.STORE);
-            scuOperationConfig.setCancelAfter(timings.getCancelAfter());
-            List<String> iuidList = new ArrayList<>();
-            List<String> keys = new ArrayList<>();
-            try {
-                if (storeImage.getDicomObject() != null) {
-                    Object dicomObject = storeImage.getDicomObject();
-                    if (!(dicomObject instanceof DicomObject))
-                        throw new ModuleException(DicomError.INVALID_DICOM_OBJECT, new RuntimeException(dicomObject.getClass().toString()));
-                    DicomObject dicom = (DicomObject) dicomObject;
+        ScuOperationConfig scuOperationConfig = new ScuOperationConfig(ScuType.STORE);
+        scuOperationConfig.setCancelAfter(timings.getCancelAfter());
+        List<String> iuidList = new ArrayList<>();
+        List<String> keys = new ArrayList<>();
+        try {
+            if (storeImage.getDicomObject() != null) {
+                Object dicomObject = storeImage.getDicomObject();
+                if (!(dicomObject instanceof DicomObject))
+                    throw new ModuleException(DicomError.INVALID_DICOM_OBJECT, new RuntimeException(dicomObject.getClass().toString()));
+                DicomObject dicom = (DicomObject) dicomObject;
 
-                    // Send the content
-                    Attributes data = dicom.getContent();
-                    AttribUtils.updateTags(data, changeTags);
-                    StoreScu.execute(connection, scuOperationConfig, data, null, iuidList);
-                } else if (storeImage.getFileName() != null) {
-                    String fileName = storeImage.getFileName();
+                // Send the content
+                Attributes data = dicom.getContent();
+                AttribUtils.updateTags(data, changeTags);
+                StoreScu.execute(connection, scuOperationConfig, data, null, iuidList);
+            } else if (storeImage.getFileName() != null) {
+                String fileName = storeImage.getFileName();
+                DicomFileType dft = DicomFileType.parse(fileName);
+                if (DicomFileType.canStore(dft)) {
+                    StoreScu.execute(connection, scuOperationConfig, fileName, dft, changeTags, iuidList);
+                } else {
+                    throw new ModuleException(DicomError.FILE_IO, new RuntimeException("File cannot be read or is an unknown type"));
+                }
+            } else if (storeImage.getFolderName() != null) {
+                String folderName = storeImage.getFolderName();
+                if (!DicomFileType.parse(folderName).equals(DicomFileType.DIRECTORY))
+                    throw new ModuleException(DicomError.FILE_IO, new RuntimeException("Cannot read Folder"));
+                List<java.nio.file.Path> fileList = StoreUtils.getFileList(folderName);
+                for (java.nio.file.Path fileName : fileList) {
+                    DicomFileType dft = DicomFileType.parse(fileName.toString());
+                    if (DicomFileType.canStore(dft)) { // Quietly ignore anything we cannot store
+                        StoreScu.execute(connection, scuOperationConfig, fileName.toString(), dft, changeTags, iuidList);
+                    }
+                }
+            } else if (storeImage.getListOfFiles() != null) {
+                // Flatten the list, since it could be a combination of filenames and/or folders
+                Map<String, DicomFileType> allFiles = new HashMap<>();
+                for (String fileName : storeImage.getListOfFiles()) {
                     DicomFileType dft = DicomFileType.parse(fileName);
                     if (DicomFileType.canStore(dft)) {
-                        StoreScu.execute(connection, scuOperationConfig, fileName, dft, changeTags, iuidList);
+                        allFiles.put(fileName, dft);
+                    } else if (dft.equals(DicomFileType.DIRECTORY)) {
+                        List<java.nio.file.Path> fileList = StoreUtils.getFileList(fileName);
+                        for (java.nio.file.Path file : fileList) {
+                            DicomFileType dft2 = DicomFileType.parse(file.toString());
+                            if (DicomFileType.canStore(dft2)) { // Quietly ignore anything we cannot store
+                                allFiles.put(file.toString(), dft2);
+                            }
+                        }
                     } else {
                         throw new ModuleException(DicomError.FILE_IO, new RuntimeException("File cannot be read or is an unknown type"));
                     }
+                }
+                for (Map.Entry<String, DicomFileType> entry : allFiles.entrySet()) {
+                    StoreScu.execute(connection, scuOperationConfig, entry.getKey(), entry.getValue(), changeTags, iuidList);
+                }
+            } else if (storeImage.getObjectStore() != null) {
+                storeScuFromObjectStore(connection, storeImage.getObjectStore(), changeTags, scuOperationConfig, iuidList, keys);
+            }
+        } catch (IOException e) {
+            throw new ModuleException(DicomError.CONNECTIVITY, e);
+        } finally {
+            if (deleteSourceFiles) {
+                if (storeImage.getFileName() != null) {
+                    StoreUtils.deleteFolder(storeImage.getFileName());
                 } else if (storeImage.getFolderName() != null) {
-                    String folderName = storeImage.getFolderName();
-                    if (!DicomFileType.parse(folderName).equals(DicomFileType.DIRECTORY))
-                        throw new ModuleException(DicomError.FILE_IO, new RuntimeException("Cannot read Folder"));
-                    List<java.nio.file.Path> fileList = StoreUtils.getFileList(folderName);
-                    for (java.nio.file.Path fileName : fileList) {
-                        DicomFileType dft = DicomFileType.parse(fileName.toString());
-                        if (DicomFileType.canStore(dft)) { // Quietly ignore anything we cannot store
-                            StoreScu.execute(connection, scuOperationConfig, fileName.toString(), dft, changeTags, iuidList);
-                        }
-                    }
+                    StoreUtils.deleteFolder(storeImage.getFolderName());
                 } else if (storeImage.getListOfFiles() != null) {
-                    // Flatten the list, since it could be a combination of filenames and/or folders
-                    Map<String, DicomFileType> allFiles = new HashMap<>();
                     for (String fileName : storeImage.getListOfFiles()) {
-                        DicomFileType dft = DicomFileType.parse(fileName);
-                        if (DicomFileType.canStore(dft)) {
-                            allFiles.put(fileName, dft);
-                        } else if (dft.equals(DicomFileType.DIRECTORY)) {
-                            List<java.nio.file.Path> fileList = StoreUtils.getFileList(fileName);
-                            for (java.nio.file.Path file : fileList) {
-                                DicomFileType dft2 = DicomFileType.parse(file.toString());
-                                if (DicomFileType.canStore(dft2)) { // Quietly ignore anything we cannot store
-                                    allFiles.put(file.toString(), dft2);
-                                }
-                            }
-                        } else {
-                            throw new ModuleException(DicomError.FILE_IO, new RuntimeException("File cannot be read or is an unknown type"));
-                        }
-                    }
-                    for (Map.Entry<String, DicomFileType> entry : allFiles.entrySet()) {
-                        StoreScu.execute(connection, scuOperationConfig, entry.getKey(), entry.getValue(), changeTags, iuidList);
+                        StoreUtils.deleteFolder(fileName);
                     }
                 } else if (storeImage.getObjectStore() != null) {
-                    storeScuFromObjectStore(connection, storeImage.getObjectStore(), changeTags, scuOperationConfig, iuidList, keys);
-                }
-            } catch (IOException e) {
-                throw new ModuleException(DicomError.CONNECTIVITY, e);
-            } finally {
-                if (deleteSourceFiles) {
-                    if (storeImage.getFileName() != null) {
-                        StoreUtils.deleteFolder(storeImage.getFileName());
-                    } else if (storeImage.getFolderName() != null) {
-                        StoreUtils.deleteFolder(storeImage.getFolderName());
-                    } else if (storeImage.getListOfFiles() != null) {
-                        for (String fileName : storeImage.getListOfFiles()) {
-                            StoreUtils.deleteFolder(fileName);
+                    try {
+                        ObjectStore<byte[]> objectStore = storeImage.getObjectStore();
+                        for (String keyName : keys) {
+                            objectStore.remove(keyName);
                         }
-                    } else if (storeImage.getObjectStore() != null) {
-                        try {
-                            ObjectStore<byte[]> objectStore = storeImage.getObjectStore();
-                            for (String keyName : keys) {
-                                objectStore.remove(keyName);
-                            }
-                        } catch (Exception ignore) {
-                            // Ignore
-                        }
+                    } catch (Exception ignore) {
+                        // Ignore
                     }
                 }
             }
-            return iuidList;
         }
+        return iuidList;
+
     }
 
     private void storeScuFromObjectStore(ScuConnection connection, ObjectStore<byte[]> objectStore, Map<String, String> changeTags, ScuOperationConfig scuOperationConfig, List<String> iuidList, List<String> keys) {

--- a/src/main/java/org/mule/module/dicom/internal/source/GetScuListener.java
+++ b/src/main/java/org/mule/module/dicom/internal/source/GetScuListener.java
@@ -1,0 +1,56 @@
+package org.mule.module.dicom.internal.source;
+
+import org.mule.module.dicom.api.content.DicomObject;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+
+public class GetScuListener {
+    private static final ConcurrentMap<String, GetScuResults> sources = new ConcurrentHashMap<>();
+
+    private GetScuListener() { }
+
+    public static void start(String flowName, String seriesName) throws IOException {
+        GetScuResults source = sources.get(flowName);
+        if (source != null) {
+            synchronized (source.getLock()) {
+                GetScuMessage message = new GetScuMessage(seriesName, "start");
+                source.send(message);
+                message.waitForCompletion();
+            }
+        } else {
+            throw new IOException(String.format("There is no Flow called %s with a Get Scu Results listener.", flowName));
+        }
+    }
+
+    public static void publish(String flowName, String seriesName, String iuid, DicomObject dicomObject) throws IOException {
+        GetScuResults source = sources.get(flowName);
+        if (source != null) {
+            synchronized (source.getLock()) {
+                GetScuMessage message = new GetScuMessage(seriesName, "receive", iuid, dicomObject);
+                source.send(message);
+                message.waitForCompletion();
+            }
+        }
+    }
+
+    public static void stop(String flowName, String seriesName) throws IOException {
+        GetScuResults source = sources.get(flowName);
+        if (source != null) {
+            synchronized (source.getLock()) {
+                GetScuMessage message = new GetScuMessage(seriesName, "stop");
+                source.send(message);
+                message.waitForCompletion();
+            }
+        }
+    }
+
+    public static void attach(GetScuResults getScuResults) {
+        sources.put(getScuResults.getFlowName(), getScuResults);
+    }
+
+    public static void detach(GetScuResults getScuResults) {
+        sources.remove(getScuResults.getFlowName());
+    }
+
+}

--- a/src/main/java/org/mule/module/dicom/internal/source/GetScuMessage.java
+++ b/src/main/java/org/mule/module/dicom/internal/source/GetScuMessage.java
@@ -1,0 +1,62 @@
+package org.mule.module.dicom.internal.source;
+
+import org.mule.module.dicom.api.content.DicomObject;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+public class GetScuMessage {
+    private final Semaphore semaphore = new Semaphore(1);
+
+    private final String seriesName;
+    public String getSeriesName() { return seriesName; }
+
+    private final String action;
+    public String getAction() { return action; }
+
+    private final String iuid;
+    public String getIuid() { return iuid; }
+
+    private final DicomObject dicomObject;
+    public DicomObject getDicomObject() { return dicomObject; }
+
+    private org.mule.runtime.api.message.Error error;
+    public void setError(org.mule.runtime.api.message.Error error) { this.error = error; }
+    public org.mule.runtime.api.message.Error getError() { return error; }
+
+    public GetScuMessage(String seriesName, String action) {
+        this.error = null;
+        this.seriesName = seriesName;
+        this.action = action;
+        this.iuid = null;
+        this.dicomObject = null;
+    }
+    public GetScuMessage(String seriesName, String action, String iuid, DicomObject dicomObject) {
+        this.error = null;
+        this.seriesName = seriesName;
+        this.action = action;
+        this.iuid = iuid;
+        this.dicomObject = dicomObject;
+    }
+
+    public void lock() throws InterruptedException {
+        semaphore.acquire();
+    }
+    public void release() {
+        semaphore.release();
+    }
+    public void waitForCompletion() throws IOException {
+        try {
+            semaphore.acquire();
+            if (error != null) {
+                throw new IOException(error.getCause());
+            }
+        } catch (InterruptedException e) {
+            Thread t = Thread.currentThread();
+            t.getUncaughtExceptionHandler().uncaughtException(t, e);
+            t.interrupt();
+        } finally {
+            semaphore.release();
+        }
+    }
+}

--- a/src/main/java/org/mule/module/dicom/internal/source/GetScuResults.java
+++ b/src/main/java/org/mule/module/dicom/internal/source/GetScuResults.java
@@ -1,0 +1,93 @@
+package org.mule.module.dicom.internal.source;
+
+import org.mule.module.dicom.internal.config.DicomObjectOutputResolver;
+import org.mule.runtime.api.component.location.ComponentLocation;
+import org.mule.runtime.extension.api.annotation.execution.OnError;
+import org.mule.runtime.extension.api.annotation.execution.OnSuccess;
+import org.mule.runtime.extension.api.annotation.metadata.MetadataScope;
+import org.mule.runtime.extension.api.annotation.param.display.DisplayName;
+import org.mule.runtime.extension.api.annotation.param.display.Summary;
+import org.mule.runtime.extension.api.runtime.operation.Result;
+import org.mule.runtime.extension.api.runtime.source.Source;
+import org.mule.runtime.extension.api.runtime.source.SourceCallback;
+import org.mule.runtime.extension.api.runtime.source.SourceCallbackContext;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+@DisplayName("Get SCU Results")
+@Summary("Receives each image from the Get SCU to Flow operation")
+@MetadataScope(outputResolver = DicomObjectOutputResolver.class)
+public class GetScuResults extends Source<Object, Map<String, String>> {
+    private static final String MSGCONTEXT = "_scuMessage";
+    private final String uuid = UUID.randomUUID().toString();
+    public String getUuid() { return uuid; }
+    private String flowName;
+    public String getFlowName() { return flowName; }
+    private final Object lock = new Object();
+    public Object getLock() { return lock; }
+
+    private ComponentLocation location;
+    private SourceCallback<Object, Map<String, String>> sourceCallback;
+
+    public void send(GetScuMessage message) {
+        try {
+            message.lock();
+            SourceCallbackContext ctx = sourceCallback.createContext();
+            ctx.addVariable(MSGCONTEXT, message);
+            Map<String, String> attributes = new HashMap<>();
+            attributes.put("action", message.getAction());
+            attributes.put("seriesName", message.getSeriesName());
+            if (message.getIuid() != null) {
+                attributes.put("iuid", message.getIuid());
+                sourceCallback.handle(Result.<Object, Map<String, String>>builder()
+                        .output(message.getDicomObject())
+                        .attributes(attributes)
+                        .build(), ctx);
+            } else {
+                sourceCallback.handle(Result.<Object, Map<String, String>>builder()
+                        .output(null)
+                        .attributes(attributes)
+                        .build(), ctx);
+            }
+        } catch (InterruptedException e) {
+            message.release();
+            Thread t = Thread.currentThread();
+            t.getUncaughtExceptionHandler().uncaughtException(t, e);
+            t.interrupt();
+        }
+    }
+
+    @Override
+    public void onStart(SourceCallback<Object, Map<String, String>> sourceCallback) {
+        this.sourceCallback = sourceCallback;
+        flowName = location.getLocation().substring(0, location.getLocation().indexOf('/'));
+        GetScuListener.attach(this);
+    }
+
+    @OnSuccess
+    public void onSuccess(SourceCallbackContext context) {
+        Optional<Object> messageObject = context.getVariable(MSGCONTEXT);
+        if (messageObject.isPresent()) {
+            GetScuMessage message = (GetScuMessage)messageObject.get();
+            message.release();
+        }
+    }
+
+    @OnError
+    public void onError(SourceCallbackContext context, org.mule.runtime.api.message.Error error) {
+        Optional<Object> messageObject = context.getVariable(MSGCONTEXT);
+        if (messageObject.isPresent()) {
+            GetScuMessage message = (GetScuMessage)messageObject.get();
+            message.setError(error);
+            message.release();
+        }
+    }
+
+    @Override
+    public void onStop() {
+        GetScuListener.detach(this);
+    }
+}

--- a/src/main/java/org/mule/module/dicom/internal/store/MuleGetScuStore.java
+++ b/src/main/java/org/mule/module/dicom/internal/store/MuleGetScuStore.java
@@ -1,0 +1,63 @@
+package org.mule.module.dicom.internal.store;
+
+import org.dcm4che3.data.Attributes;
+import org.dcm4che3.data.Tag;
+import org.dcm4che3.net.Association;
+import org.dcm4che3.net.PDVInputStream;
+import org.dcm4che3.net.pdu.PresentationContext;
+import org.mule.module.dicom.api.content.DicomObject;
+import org.mule.module.dicom.internal.source.GetScuListener;
+import org.mule.module.dicom.internal.util.AttribUtils;
+
+import java.io.IOException;
+import java.util.*;
+
+public class MuleGetScuStore implements MuleStore {
+    private final String flowName;
+    private final String seriesName;
+
+    public MuleGetScuStore(String flowName, String seriesName) throws IOException {
+        fileList = new ArrayList<>();
+        this.flowName = flowName;
+        this.seriesName = seriesName;
+        GetScuListener.start(flowName, seriesName);
+    }
+
+    @Override
+    public boolean isNull() {
+        return false;
+    }
+
+    @Override
+    public void waitForFinish() throws IOException {
+        GetScuListener.stop(flowName, seriesName);
+    }
+
+    private final List<String> fileList;
+    @Override
+    public List<String> getFileList() { return fileList; }
+
+    private String currentFileName;
+    @Override
+    public String getCurrentFileName() { return currentFileName; }
+
+    @Override
+    public void process(Association as, PresentationContext pc, PDVInputStream payload) throws IOException {
+        String tsuid = pc.getTransferSyntax();
+        Attributes image = payload.readDataset(tsuid);
+        // Make sure the TransferSyntax is on the image
+        if (image.getString(Tag.TransferSyntaxUID) == null) {
+            Map<String, String> setTags = new HashMap<>();
+            setTags.put("TransferSyntaxUID", tsuid);
+            AttribUtils.updateTags(image, setTags);
+        }
+        DicomObject dicomObject = new DicomObject(image, pc.getTransferSyntax(), as.getRemoteAET(), as.getRemoteImplClassUID(), as.getRemoteImplVersionName());
+        String iuid = AttribUtils.getFirstString(image, new Integer[]{Tag.AffectedSOPInstanceUID, Tag.MediaStorageSOPInstanceUID, Tag.SOPInstanceUID});
+        if (iuid != null) currentFileName = iuid;
+        else currentFileName = "";
+        if (iuid != null) {
+            fileList.add(iuid);
+            GetScuListener.publish(flowName, seriesName, iuid, dicomObject);
+        }
+    }
+}


### PR DESCRIPTION
Using Get SCU can take a long time for a large series since the flow has to wait for all images to be received before continuing. These changes improve the locking and synchronization of all SCU operations. They also add a new way to call Get SCU and have each image sent to another flow.